### PR TITLE
Automatically refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-login-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Auth and User services for Angular v2 and up. Requires backend REST service.",
   "main": "bundles/login.umd.js",
   "module": "index.js",

--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -1,25 +1,40 @@
 import { Router } from '@angular/router';
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
+import { Http, Response, Headers } from '@angular/http';
 
 import { Broadcaster } from '../shared/broadcaster.service';
+import { Token } from '../user/token';
+import { AUTH_API_URL } from '../shared/auth-api';
 
 @Injectable()
 export class AuthenticationService {
   private authToken: string = '';
+  private refreshInterval: number;
+  private apiUrl: string;
+  private clearTimeoutId: any;
 
   constructor(private router: Router,
-              private broadcaster: Broadcaster) { }
+              private broadcaster: Broadcaster,
+              @Inject(AUTH_API_URL) apiUrl: string,
+              private http: Http) {
+    this.apiUrl = apiUrl;
+  }
 
   isLoggedIn(): boolean {
     let token = localStorage.getItem('auth_token');
     if (token) {
       this.authToken = token;
+      // refresh the token in five seconds to make sure we have expiry and a running timer - only do this first time in
+      if(!this.refreshInterval) {
+        this.setupRefreshTimer(15);
+      }
       return true;
     }
-    let params:any = this.getUrlParams();
-    if ('token' in params) {
-      this.authToken = params['token'];
-      localStorage.setItem('auth_token', this.authToken);
+    let params: any = this.getUrlParams();
+    if ('token_json' in params) {
+      let tokenJson = decodeURIComponent(params['token_json']);
+      let token = this.processTokenResponse(JSON.parse(tokenJson));
+      this.setupRefreshTimer(token.expires_in);
       return true;
     }
     return false;
@@ -28,6 +43,9 @@ export class AuthenticationService {
   logout(redirect: boolean = false) {
     this.authToken = '';
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('refresh_token');
+    clearTimeout(this.clearTimeoutId);
+    this.refreshInterval = null;
     this.broadcaster.broadcast('logout', 1);
     if (redirect) {
       this.router.navigate(['login']);
@@ -38,13 +56,49 @@ export class AuthenticationService {
     if (this.isLoggedIn()) return this.authToken;
   }
 
+  setupRefreshTimer(refreshInSeconds: number) {
+    if (!this.clearTimeoutId) {
+      let refreshInMs = Math.round(refreshInSeconds * .9) * 1000;
+      console.log('Refreshing token in: ' + refreshInMs + ' milliseconds.');
+      this.refreshInterval = refreshInMs;
+      this.clearTimeoutId = setTimeout(() => this.refreshToken(), refreshInMs);
+    }
+  }
+
+  refreshToken() {
+    if (this.isLoggedIn()) {
+      this.clearTimeoutId = null;
+      let headers = new Headers({'Content-Type': 'application/json'});
+      headers.set('Authorization', 'Bearer ' + this.getToken());
+      let refreshTokenUrl = this.apiUrl + 'login/refresh';
+      let refreshToken = localStorage.getItem('refresh_token');
+      let body = JSON.stringify({"refresh_token": refreshToken});
+      this.http.post(refreshTokenUrl, body, headers)
+        .map((response: Response) => {
+          let responseJson = response.json();
+          let token = this.processTokenResponse(responseJson.token);
+          this.setupRefreshTimer(token.expires_in);
+        }).subscribe( () => {
+          console.log('token refreshed at:' + Date.now());
+        });
+    }
+  }
+
   getUrlParams(): Object {
     let query = window.location.search.substr(1);
-    let result:any = {};
-    query.split('&').forEach(function(part) {
-      let item:any = part.split('=');
+    let result: any = {};
+    query.split('&').forEach(function (part) {
+      let item: any = part.split('=');
       result[item[0]] = decodeURIComponent(item[1]);
     });
     return result;
+  }
+
+  processTokenResponse(response: any): Token {
+    let token = response as Token;
+    this.authToken = token.access_token;
+    localStorage.setItem('auth_token', this.authToken);
+    localStorage.setItem('refresh_token', token.refresh_token);
+    return token;
   }
 }

--- a/src/app/user/token.ts
+++ b/src/app/user/token.ts
@@ -1,0 +1,7 @@
+export class Token  {
+  'access_token': string;
+  'expires_in': number;
+  'refresh_expires_in': number;
+  'refresh_token': string;
+  'token_type': string;
+}


### PR DESCRIPTION
This adds support for automatically refreshing the auth token prior to expiration (calculated at 90% of the expiration time remaining).  

Logout clears the timeout and with no session data in memory, an initial refresh takes place 15 seconds in to make sure expiry and the refresh token are correct.

Package.json version also bumped.

@joshuawilson @pmuir 