### PR TITLE
add a piepline to update downstream dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+@Library('github.com/fabric8io/fabric8-pipeline-library@master')
+def utils = new io.fabric8.Utils()
+clientsNode{
+    ws {
+        checkout scm
+
+        def releaseVersion
+        container('clients'){
+            releaseVersion = utils.getLatestVersionFromTag()
+        }
+
+        pushPackageJSONChangePR{
+            propertyName = 'ngx-login-client'
+            projects = [
+                    'fabric8-ui/ngx-fabric8-wit',
+                    'fabric8io/fabric8-ui'
+            ]
+            version = releaseVersion
+        }
+    }
+}
+


### PR DESCRIPTION
This is an initial attempt and automating the update of downstream npm package.json files using github pull requests so that CI for each project runs on the newly released version.

Once this merges we should see a job appear on http://jenkins.cd.k8s.fabric8.io/job/fabric8-cd/.  

For now this pipeline will:
- require a manual trigger once a release has finished on centosci, we can automate this later with polling or webhooks
- get the latest release version using the git tag from this repo
- clone `fabric8-ui/ngx-fabric8-wit`& `fabric8io/fabric8-ui`
- checkout a new versionupdate branch
- update the package.json with the latest release version of `ngx-login-client` using the git tag form above
- commit & push
- make a github pull requests to master
- wait for CI to run and the PR's to merge

This is an initial attempt, if it works as planned we can duplicate the Jenkinsfile into other repos and simply update the downstream projects they need to update.  https://github.com/rawlingsj/ngx-login-client/blob/master/Jenkinsfile#L15-L16

After this we can also look to trigger the release in centosci for those downstream projects or update their Jenkinsfiles to perform the npm build + docker push themselves like the other fabric8 projects.  But this is just a start and aimed to be a quick win to avoid manual updates of package.json files.

CC @joshuawilson 
