### PR TITLE
fix(authreload): use correct token on refresh

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -67,7 +67,7 @@ export class AuthenticationService {
     if (token) {
       if (!this.clearTimeoutId) {
         // kick off initial token refresh
-        this.refreshTokens.next({} as Token);
+        this.refreshTokens.next({"access_token": token} as Token);
         this.setupRefreshTimer(15);
       }
       return true;


### PR DESCRIPTION
Simple fix to ensure that all consumers aren't broken if they use their own httpmodule