### PR TITLE
Add comment to warn about potential issue with refresh token with the big expiry

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -97,6 +97,9 @@ export class AuthenticationService {
       console.log('Refreshing token in: ' + refreshInMs + ' milliseconds.');
       this.refreshInterval = refreshInMs;
       if (process.env.ENV !== 'inmemory') {
+        // setTimeout() uses a 32 bit int to store the delay. So the max value allowed is 2147483647
+        // The bigger number will cause immediate refreshing
+        // but since we refresh in 10 minutes or in refreshInSeconds whatever is sooner we are good
         this.clearTimeoutId = setTimeout(() => this.refreshToken(), refreshInMs);
       }
     }


### PR DESCRIPTION
setTimeout() uses a 32 bit int to store the delay. So the max value allowed is 2147483647
But since we switched to 30 day tokens the token expiry now is bigger than that int that can causes immediate refreshing.
Actually we refresh in 10 minutes or in 90% of the expiry time whatever is sooner and that is not a problem here. We missed that 10-minute check in www.openshift.io and had a problem there - https://github.com/fabric8io/fabric8-ui/issues/1049

But it would be safer if we have a comment explaining that we should always check the refresh timeout number in case we change that 10-minute rule later.