### PR TITLE
fix(token): 400 error when fetching oso token

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -141,6 +141,9 @@ export class AuthenticationService {
       let options = new RequestOptions({ headers: headers });
       return this.http.get(tokenUrl, options)
         .map(response => processToken(response))
+        .catch(error => {
+          return Observable.of({} as Token);
+        })
         .do(token => localStorage.setItem(broker + '_token', token.access_token))
         .map(t => t.access_token);
     })


### PR DESCRIPTION
The AuthenticationService.createFederatedToken function does not handle response status 400 when OpenShift token is not available. This prevents fabric8-ui from displaying the getting started page upon login.
