### PR TITLE
Revert token refresh endpoint path update

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -113,7 +113,7 @@ export class AuthenticationService {
     if (this.isLoggedIn()) {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let options: RequestOptions = new RequestOptions({ headers: headers });
-      let refreshTokenUrl = this.apiUrl + 'token/refresh';
+      let refreshTokenUrl = this.apiUrl + 'login/refresh';
       let refreshToken = localStorage.getItem('refresh_token');
       let body = JSON.stringify({ 'refresh_token': refreshToken });
       this.http.post(refreshTokenUrl, body, options)


### PR DESCRIPTION
This PR reverts https://github.com/fabric8-ui/ngx-login-client/pull/65 to fix token refresh.
We should not have pushed that update without changing URL from WIT to Auth. Because WIT's endpoint is https://api.openshift.io/api/login/refresh which proxies to https://auth.openshift.io/api/token/refresh
So, https://api.openshift.io/api/token/refresh doesn't exist.

Fixes https://github.com/openshiftio/openshift.io/issues/1135