### PR TITLE
fix(github): update url to fetch github token

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -38,7 +38,7 @@ export class AuthenticationService {
     this.ssoUrl = ssoUrl;
     this.realm = realm;
     this.openShiftToken = this.createFederatedToken(this.openshift, (response: Response) => response.json() as Token);
-    this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => this.queryAsToken(response.text()));
+    this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => response.json() as Token);
   }
 
   logIn(tokenParameter: string): boolean {
@@ -113,7 +113,7 @@ export class AuthenticationService {
     if (this.isLoggedIn()) {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let options: RequestOptions = new RequestOptions({ headers: headers });
-      let refreshTokenUrl = this.apiUrl + 'login/refresh';
+      let refreshTokenUrl = this.apiUrl + 'token/refresh';
       let refreshToken = localStorage.getItem('refresh_token');
       let body = JSON.stringify({ 'refresh_token': refreshToken });
       this.http.post(refreshTokenUrl, body, options)
@@ -150,6 +150,9 @@ export class AuthenticationService {
     let res = this.refreshTokens.switchMap(token => {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let tokenUrl = this.ssoUrl + `auth/realms/${this.realm}/broker/${broker}/token`;
+      if ( broker == this.github ){
+        tokenUrl = this.apiUrl + `token?for=https://github.com`;
+      }
       headers.set('Authorization', `Bearer ${token.access_token}`);
       let options = new RequestOptions({ headers: headers });
       return this.http.get(tokenUrl, options)

--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -38,7 +38,15 @@ export class AuthenticationService {
     this.ssoUrl = ssoUrl;
     this.realm = realm;
     this.openShiftToken = this.createFederatedToken(this.openshift, (response: Response) => response.json() as Token);
-    this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => response.json() as Token);
+    
+    // TODO: Remove the conditional block after fabric8-ui's related changes are in master
+    if ( ! this.apiUrl.startsWith("https://api.") ){
+      this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => response.json() as Token);
+    }
+    else{
+      this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => this.queryAsToken(response.text()));
+    }
+
   }
 
   logIn(tokenParameter: string): boolean {
@@ -114,6 +122,14 @@ export class AuthenticationService {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let options: RequestOptions = new RequestOptions({ headers: headers });
       let refreshTokenUrl = this.apiUrl + 'token/refresh';
+
+
+      // ensure nothing breaks even if the corresponding changes in fabric8-ui/fabric8-ui
+      // are not merged when this is released.
+      if ( this.apiUrl.startsWith("https://api.") ){
+        // keep the old one.
+        refreshTokenUrl = this.apiUrl + 'login/refresh';
+      }
       let refreshToken = localStorage.getItem('refresh_token');
       let body = JSON.stringify({ 'refresh_token': refreshToken });
       this.http.post(refreshTokenUrl, body, options)
@@ -150,7 +166,10 @@ export class AuthenticationService {
     let res = this.refreshTokens.switchMap(token => {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let tokenUrl = this.ssoUrl + `auth/realms/${this.realm}/broker/${broker}/token`;
-      if ( broker == this.github ){
+      if ( broker == this.github && !this.apiUrl.startsWith("https://api.") ){
+        // the second condition ensures that if this commit moves to master
+        // nothing breaks even if the corresponding changes in fabric8-ui/fabric8-ui are
+        // yet to be merged.
         tokenUrl = this.apiUrl + `token?for=https://github.com`;
       }
       headers.set('Authorization', `Bearer ${token.access_token}`);


### PR DESCRIPTION
**Note** 
- Should be merged along with https://github.com/fabric8-ui/fabric8-ui/pull/2011 
- In case it is not done so, I've added backward compatibility - in case this widget gets released and used in production before  https://github.com/fabric8-ui/fabric8-ui/pull/2011  is merged & deployed.
- Please use the PR title as commit message , and do a 'Squash and Merge' since my 'sub-commits' are uninteresting.

What this PR solves ?
- migration of github token url from sso url to auth url.
- configures refresh token url and the github token url for use with the auth service.