### PR TITLE
AUTH: Disable token refresh for Planner testing

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -100,7 +100,9 @@ export class AuthenticationService {
       let refreshInMs = Math.round(refreshInSeconds * .9) * 1000;
       console.log('Refreshing token in: ' + refreshInMs + ' milliseconds.');
       this.refreshInterval = refreshInMs;
-      if (process.env.ENV !== 'inmemory') {
+      // Disable token refresh timeout when LOGIN_CLIENT_NO_REFRESH is set
+      // This is necessary to run fabric8-planner end-to-end tests
+      if ( ! (process.env.ENV === 'inmemory' || process.env.ENV === 'LOGIN_CLIENT_NO_REFRESH')) {
         // setTimeout() uses a 32 bit int to store the delay. So the max value allowed is 2147483647
         // The bigger number will cause immediate refreshing
         // but since we refresh in 10 minutes or in refreshInSeconds whatever is sooner we are good


### PR DESCRIPTION
When trying to run the e2e tests for fabric8-planner the tests never start as ngx-login-client keeps on retrying. This causes our e2e tests to wait indefinitely. This PR fixes that issue.

When `NODE_ENV='LOGIN_CLIENT_NO_REFRESH` is set, token refresh won't be done repeatedly.