### PR TITLE
fix(openshift): do not fetch openshift token anymore

### DIFF
--- a/src/app/auth/authentication.service.spec.ts
+++ b/src/app/auth/authentication.service.spec.ts
@@ -232,23 +232,6 @@ describe('Service: Authentication service', () => {
   });
 
 
-  it('Openshift token processing - not logged in', async(() => {
-      mockService.connections.subscribe((connection: any) => {
-      connection.mockRespond(new Response(
-        new ResponseOptions({
-          body: tokenJson,
-          status: 200
-        })
-      ));
-    });
-    spyOn(authenticationService, 'setupRefreshTimer');
-
-    authenticationService.getOpenShiftToken().subscribe(output => {
-      expect(output == '');
-      expect(localStorage.getItem('openshift-v3_token')).toBeNull();
-    });
-  }));
-
   it('Github token processing', (done) => {
     // given
     mockService.connections.subscribe((connection: any) => {

--- a/src/app/auth/authentication.service.spec.ts
+++ b/src/app/auth/authentication.service.spec.ts
@@ -128,33 +128,6 @@ describe('Service: Authentication service', () => {
     authenticationService.logIn(tokenJson);
   });
 
-  it('Openshift token processing', (done) => {
-    // given
-    mockService.connections.subscribe((connection: any) => {
-      connection.mockRespond(new Response(
-        new ResponseOptions({
-          body: tokenJson,
-          status: 201
-        })
-      ));
-    });
-    spyOn(authenticationService, 'setupRefreshTimer');
-
-    broadcaster.on('loggedin').subscribe((data: number) => {
-      let token = JSON.parse(tokenJson);
-      authenticationService.getOpenShiftToken().subscribe(output => {
-        // then
-        expect(output == token.access_token);
-        expect(localStorage.getItem('openshift-v3_token')).toBe(token.access_token);
-        authenticationService.logout();
-        done();
-      });
-    });
-
-    // when
-    authenticationService.logIn(tokenJson);
-  });
-
   it('Openshift proxy token retrieval', (done) => {
     // given
     mockService.connections.subscribe((connection: any) => {

--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -16,7 +16,6 @@ export interface ProcessTokenResponse {
 @Injectable()
 export class AuthenticationService {
 
-  public openShiftToken: Observable<string>;
   public gitHubToken: Observable<string>;
   private refreshInterval: number;
   private apiUrl: string;
@@ -38,8 +37,6 @@ export class AuthenticationService {
     this.apiUrl = apiUrl;
     this.ssoUrl = ssoUrl;
     this.realm = realm;
-    // this is still returning the actual openshift token to detect if the user is logged in or not
-    this.openShiftToken = this.createFederatedToken(this.openshift, (response: Response) => response.json() as Token);
     this.gitHubToken = this.createFederatedToken(this.github, (response: Response) => response.json() as Token);
   }
 


### PR DESCRIPTION
Keycloak token url was being called for the `openshift-v3` token  whenever the class was loaded at runtime.