### PR TITLE
feat(email-verification): added method in userService to send email verification link to a user

### DIFF
--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -186,6 +186,17 @@ export class UserService {
   }
 
   /**
+   * Send email verification link to user.
+   */
+  sendEmailVerificationLink(): Observable<any> {
+    return this.http
+      .post(this.usersUrl + '/verificationcode', null, { headers: this.headers })
+      .map(response => {
+        return response;
+      })
+  }
+
+  /**
    * @deprecated since v0.4.4. No replacement is provided.
    *
    */

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
-import { Headers, Http } from '@angular/http';
+import { Headers, Http, Response } from '@angular/http';
 
 import {
   Observable,
@@ -182,18 +182,18 @@ export class UserService {
       .get( `${this.usersUrl}?filter[username]=${username}`, { headers: this.headers })
       .map(response => {
         return response.json().data as User[];
-      })
+      });
   }
 
   /**
    * Send email verification link to user.
    */
-  sendEmailVerificationLink(): Observable<any> {
+  sendEmailVerificationLink(): Observable<Response> {
     return this.http
-      .post(this.usersUrl + '/verificationcode', null, { headers: this.headers })
-      .map(response => {
+      .post(this.usersUrl + '/verificationcode', '', { headers: this.headers })
+      .map((response: Response) => {
         return response;
-      })
+      });
   }
 
   /**


### PR DESCRIPTION
Fixes - https://github.com/fabric8-services/fabric8-auth/issues/455

[Wireframe](https://redhat.invisionapp.com/share/E9FH915D3U7#/screens/285588330) for the design where the link will be there if a user's email is not verified. An option for the user to resend verification link to his email.