### PR TITLE
fix(token): check validity of OSO token when checking for account connection

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -95,7 +95,7 @@ export class AuthenticationService {
 
   isOpenShiftConnected(cluster: string): Observable<boolean> {
     let headers = new Headers({ 'Content-Type': 'application/json' });
-    let tokenUrl = this.apiUrl + `token?for=` + cluster;
+    let tokenUrl = this.apiUrl + `token?force_pull=true&for=` + cluster;
     headers.set('Authorization', `Bearer ${this.getToken()}`);
     let options = new RequestOptions({ headers: headers });
     return this.http.get(tokenUrl, options)


### PR DESCRIPTION
Fixes: https://github.com/fabric8-services/fabric8-auth/issues/480

- Added `force_pull=true` when checking if User is connected to OSO.