### PR TITLE
fix(authentication): broadcast auth error only due to user auth failure

### DIFF
--- a/src/app/shared/http.service.spec.ts
+++ b/src/app/shared/http.service.spec.ts
@@ -1,0 +1,88 @@
+import { inject, TestBed } from '@angular/core/testing';
+import { Http, HttpModule, Response, ResponseOptions, XHRBackend } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+
+import { Broadcaster } from 'ngx-base';
+
+import { HttpService } from './http.service';
+
+describe('Http service', () => {
+
+  let httpService: HttpService;
+  let mockService: MockBackend;
+  let broadcaster: Broadcaster;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule
+      ],
+      providers: [
+        MockBackend,
+        {
+          provide: XHRBackend,
+          useExisting: MockBackend
+        },
+        HttpService,
+        Broadcaster
+      ]
+    });
+  });
+
+  beforeEach(inject(
+    [HttpService, MockBackend, Broadcaster],
+    (service: HttpService, mock: MockBackend, broadcast: Broadcaster) => {
+      httpService = service;
+      mockService = mock;
+      broadcaster = broadcast;
+    }
+  ));
+
+  it('should broadcast authenticationError event on 401 with code jwt_security_error', () => {
+    let authenticationError = false;
+    let errored = false;
+    broadcaster.on('authenticationError').subscribe(() => {
+      authenticationError = true;
+    });
+
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockError(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({errors: [{code: 'jwt_security_error'}]}),
+          status: 401
+        })
+      ));
+    });
+
+    httpService.request('test').subscribe(() => {}, () => {
+      errored = true;
+    });
+
+    expect(authenticationError).toBe(true, 'authentication error');
+    expect(errored).toBe(true, 'request error');
+  });
+
+  it('should not broadcast authenticationError event on 401', () => {
+    let authenticationError = false;
+    let errored = false;
+    broadcaster.on('authenticationError').subscribe(() => {
+      authenticationError = true;
+    });
+
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockError(new Response(
+        new ResponseOptions({
+          status: 401
+        })
+      ));
+    });
+
+    httpService.request('test').subscribe(() => {}, () => {
+      errored = true;
+    });
+
+    expect(authenticationError).toBe(false, 'authentication error');
+    expect(errored).toBe(true, 'request error');
+  });
+});
+

--- a/src/app/shared/http.service.ts
+++ b/src/app/shared/http.service.ts
@@ -46,12 +46,21 @@ export class HttpService extends Http {
 
   private catchRequestError () {
     return (res: Response) => {
-      if (res.status === 403 || ( res.status === 401 && !res.headers.has("www-authenticate"))) {
+      if (res.status === 403 || this.isAuthenticationError(res)) {
         this.broadcaster.broadcast('authenticationError', res);
       } else if (res.status === 500) {
         this.broadcaster.broadcast('communicationError', res);
       }
       return Observable.throw(res);
     };
+  }
+
+  private isAuthenticationError(res: Response): boolean {
+    if (res.status === 401) {
+      const json: any = res.json();
+      return json && Array.isArray(json.errors) &&
+          json.errors.filter((e: any) => e.code === 'jwt_security_error').length >= 1;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
fixes openshiftio/openshift.io#3325

Checks the payload of a 401 status response for the error code `jwt_security_error`. For now this is sufficient to identify user token auth failures.

In the future we can look at adding the www-authenticate header with distinguishable action.

Added test case.