### PR TITLE
fix(profile): encode url params

### DIFF
--- a/src/app/auth/authentication.service.spec.ts
+++ b/src/app/auth/authentication.service.spec.ts
@@ -179,6 +179,31 @@ describe('Service: Authentication service', () => {
     authenticationService.logIn(tokenJson);
   });
 
+  it('Openshift valid connection test if cluster needs to be encoded', (done) => {
+    // given
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: tokenJson,
+          status: 200
+        })
+      ));
+    });
+    spyOn(authenticationService, 'setupRefreshTimer');
+
+    broadcaster.on('loggedin').subscribe((data: number) => {
+      authenticationService.isOpenShiftConnected('cluster+something-else').subscribe((output) => {
+        // then
+        expect(output).toBe(true);
+        authenticationService.logout();
+        done();
+      });
+    });
+
+    // when
+    authenticationService.logIn(tokenJson);
+  });
+
   it('Openshift failed connection test', (done) => {
     // given
     mockService.connections.subscribe((connection: any) => {

--- a/src/app/auth/authentication.service.spec.ts
+++ b/src/app/auth/authentication.service.spec.ts
@@ -1,7 +1,7 @@
 
 import { async, inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, Response, ResponseOptions } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
+import { MockBackend, MockConnection } from '@angular/http/testing';
 
 import { Broadcaster } from 'ngx-base';
 
@@ -30,11 +30,11 @@ describe('Service: Authentication service', () => {
         },
         {
           provide: AUTH_API_URL,
-          useValue: "http://example.com"
+          useValue: 'http://example.com/'
         },
         {
           provide: REALM,
-          useValue: "fabric8"
+          useValue: 'fabric8'
         },
         {
           provide: SSO_API_URL,
@@ -58,7 +58,9 @@ describe('Service: Authentication service', () => {
     authenticationService.logout();
   });
 
-  let tokenJson = `{"access_token":"token","expires_in":1800,"refresh_expires_in":1800,"refresh_token":"refresh","token_type":"bearer"}`;
+  let tokenJson = `
+    {"access_token":"token","expires_in":1800,"refresh_expires_in":1800,"refresh_token":"refresh","token_type":"bearer"}
+  `;
 
   it('Can log on', (done) => {
     spyOn(authenticationService, 'setupRefreshTimer');
@@ -106,7 +108,7 @@ describe('Service: Authentication service', () => {
   });
 
   it('Refresh token processing', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({token: tokenJson}),
@@ -130,7 +132,7 @@ describe('Service: Authentication service', () => {
 
   it('Openshift proxy token retrieval', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,
@@ -144,7 +146,7 @@ describe('Service: Authentication service', () => {
       let token = JSON.parse(tokenJson);
       authenticationService.getOpenShiftToken().subscribe(output => {
         // then
-        expect(output == authenticationService.getToken());
+        expect(output === authenticationService.getToken());
         authenticationService.logout();
         done();
       });
@@ -156,7 +158,7 @@ describe('Service: Authentication service', () => {
 
   it('Openshift valid connection test', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,
@@ -181,7 +183,9 @@ describe('Service: Authentication service', () => {
 
   it('Openshift valid connection test if cluster needs to be encoded', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
+      const url = connection.request.url;
+      expect(url !== decodeURIComponent(url)).toBe(true);
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,
@@ -232,7 +236,7 @@ describe('Service: Authentication service', () => {
 
   it('Github token processing', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,
@@ -246,7 +250,7 @@ describe('Service: Authentication service', () => {
       let token = JSON.parse(tokenJson);
       authenticationService.gitHubToken.subscribe(output => {
         // then
-        expect(output == token.access_token);
+        expect(output === token.access_token);
         expect(localStorage.getItem('github_token')).toBe(token.access_token);
         authenticationService.logout();
         done();
@@ -258,7 +262,7 @@ describe('Service: Authentication service', () => {
 
   it('Github token clear', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,
@@ -286,7 +290,7 @@ describe('Service: Authentication service', () => {
 
   it('Github token processing', (done) => {
     // given
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: tokenJson,

--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -95,7 +95,7 @@ export class AuthenticationService {
 
   isOpenShiftConnected(cluster: string): Observable<boolean> {
     let headers = new Headers({ 'Content-Type': 'application/json' });
-    let tokenUrl = this.apiUrl + `token?force_pull=true&for=` + cluster;
+    let tokenUrl = this.apiUrl + `token?force_pull=true&for=` + encodeURIComponent(cluster);
     headers.set('Authorization', `Bearer ${this.getToken()}`);
     let options = new RequestOptions({ headers: headers });
     return this.http.get(tokenUrl, options)

--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -183,7 +183,7 @@ export class AuthenticationService {
       let headers = new Headers({ 'Content-Type': 'application/json' });
       let tokenUrl = this.ssoUrl + `auth/realms/${this.realm}/broker/${broker}/token`;
       if ( broker === this.github ) {
-        tokenUrl = this.apiUrl + `token?for=https://github.com`;
+        tokenUrl = this.apiUrl + `token?for=${encodeURIComponent('https://github.com')}`;
       }
       headers.set('Authorization', `Bearer ${token.access_token}`);
       let options = new RequestOptions({ headers: headers });

--- a/src/app/user/user.service.spec.ts
+++ b/src/app/user/user.service.spec.ts
@@ -64,6 +64,15 @@ describe('Service: User service', () => {
       },
       "id": "secondUserId",
       "type": "userType"
+    },
+    {
+      "attributes": {
+        "fullName": "thirdUser",
+        "imageURL": "",
+        "username": "thirdUser+1@redhat.com"
+      },
+      "id": "thirdUserId",
+      "type": "userType"
     }
   ];
 
@@ -160,6 +169,22 @@ describe('Service: User service', () => {
 
     userService.getUserByUsername('secondUser').subscribe((user) => {
       expect(user.id).toEqual('secondUserId');
+      done();
+    });
+  });
+
+  it('Get user by user name returns valid user when username == email', (done) => {
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({data: testUsers}),
+          status: 201
+        })
+      ));
+    });
+
+    userService.getUserByUsername('thirdUser+1@redhat.com').subscribe((user) => {
+      expect(user.id).toEqual('thirdUserId');
       done();
     });
   });

--- a/src/app/user/user.service.spec.ts
+++ b/src/app/user/user.service.spec.ts
@@ -1,6 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { BaseRequestOptions, Http, Response, ResponseOptions } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
+import { MockBackend, MockConnection } from '@angular/http/testing';
 
 import { Broadcaster, Logger } from 'ngx-base';
 
@@ -27,7 +27,7 @@ describe('Service: User service', () => {
         },
         {
           provide: AUTH_API_URL,
-          useValue: "http://example.com"
+          useValue: 'http://example.com'
         },
         Broadcaster,
         Logger
@@ -77,7 +77,7 @@ describe('Service: User service', () => {
   ];
 
   it('Logged in event updates user', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUser}),
@@ -97,7 +97,7 @@ describe('Service: User service', () => {
   });
 
   it('Logged out event clears user', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUser}),
@@ -123,7 +123,7 @@ describe('Service: User service', () => {
   });
 
   it('Get user by user id returns valid user', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUser}),
@@ -142,7 +142,7 @@ describe('Service: User service', () => {
   });
 
   it('Get user by user name returns null no user matched', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUsers}),
@@ -158,7 +158,7 @@ describe('Service: User service', () => {
   });
 
   it('Get user by user name returns valid user', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUsers}),
@@ -174,7 +174,9 @@ describe('Service: User service', () => {
   });
 
   it('Get user by user name returns valid user when username == email', (done) => {
-    mockService.connections.subscribe((connection: any) => {
+    mockService.connections.subscribe((connection: MockConnection) => {
+      const url = connection.request.url;
+      expect(url !== decodeURIComponent(url)).toBe(true);
       connection.mockRespond(new Response(
         new ResponseOptions({
           body: JSON.stringify({data: testUsers}),

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -95,7 +95,7 @@ export class UserService {
    */
   getUserByUserId(userId: string): Observable<User> {
     return this.http
-      .get(`${this.usersUrl}/${userId}`, { headers: this.headers })
+      .get(`${this.usersUrl}/${encodeURIComponent(userId)}`, { headers: this.headers })
       .map(response => {
         return response.json().data as User;
       });
@@ -122,7 +122,7 @@ export class UserService {
   getUsersBySearchString(search: string): Observable<User[]> {
     if (search && search !== "") {
       return this.http
-        .get(this.searchUrl + '/users?q=' + search, {headers: this.headers})
+        .get(this.searchUrl + '/users?q=' + encodeURIComponent(search), {headers: this.headers})
         .map(response => {
           return response.json().data as User[];
         });
@@ -179,7 +179,7 @@ export class UserService {
 
   filterUsersByUsername(username: string): Observable<User[]> {
     return this.http
-      .get( `${this.usersUrl}?filter[username]=${username}`, { headers: this.headers })
+      .get( `${this.usersUrl}?filter[username]=${encodeURIComponent(username)}`, { headers: this.headers })
       .map(response => {
         return response.json().data as User[];
       });


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3827
Fixes https://github.com/fabric8-services/fabric8-auth/issues/528

- Added `encodeURIComponent` for encoding URL parameters.