### PR TITLE
fix(auth): checking for auth header to verify if login is required

### DIFF
--- a/src/app/shared/check-auth-error.ts
+++ b/src/app/shared/check-auth-error.ts
@@ -1,0 +1,14 @@
+import { Response } from '@angular/http';
+
+export function isAuthenticationError(res: Response): boolean {
+  if (res.status === 401) {
+    const json: any = res.json();
+    const hasErrors: boolean = json && Array.isArray(json.errors);
+    const isJwtError: boolean = hasErrors &&
+      json.errors.filter((e: any) => e.code === 'jwt_security_error').length >= 1;
+    const authHeader = res.headers.get('www-authenticate');
+    const isLoginHeader = authHeader && authHeader.toLowerCase().includes('login');
+    return isJwtError || isLoginHeader;
+  }
+  return false;
+}

--- a/src/app/shared/http.service.ts
+++ b/src/app/shared/http.service.ts
@@ -15,6 +15,7 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/of';
 
 import { Broadcaster } from 'ngx-base';
+import { isAuthenticationError } from './check-auth-error';
 
 @Injectable()
 export class HttpService extends Http {
@@ -46,21 +47,12 @@ export class HttpService extends Http {
 
   private catchRequestError () {
     return (res: Response) => {
-      if (res.status === 403 || this.isAuthenticationError(res)) {
+      if (res.status === 403 || isAuthenticationError(res)) {
         this.broadcaster.broadcast('authenticationError', res);
       } else if (res.status === 500) {
         this.broadcaster.broadcast('communicationError', res);
       }
       return Observable.throw(res);
     };
-  }
-
-  private isAuthenticationError(res: Response): boolean {
-    if (res.status === 401) {
-      const json: any = res.json();
-      return json && Array.isArray(json.errors) &&
-          json.errors.filter((e: any) => e.code === 'jwt_security_error').length >= 1;
-    }
-    return false;
   }
 }

--- a/src/app/shared/http.service.ts
+++ b/src/app/shared/http.service.ts
@@ -42,17 +42,15 @@ export class HttpService extends Http {
         url.headers.set('Authorization', `Bearer ${token}`);
       }
     }
-    return super.request(url, options).catch(this.catchRequestError());
+    return super.request(url, options).catch(this.catchRequestError);
   }
 
-  private catchRequestError () {
-    return (res: Response) => {
-      if (res.status === 403 || isAuthenticationError(res)) {
-        this.broadcaster.broadcast('authenticationError', res);
-      } else if (res.status === 500) {
-        this.broadcaster.broadcast('communicationError', res);
-      }
-      return Observable.throw(res);
-    };
+  private catchRequestError = (res: Response) => {
+    if (res.status === 403 || isAuthenticationError(res)) {
+      this.broadcaster.broadcast('authenticationError', res);
+    } else if (res.status === 500) {
+      this.broadcaster.broadcast('communicationError', res);
+    }
+    return Observable.throw(res);
   }
 }

--- a/src/app/user/user.service.spec.ts
+++ b/src/app/user/user.service.spec.ts
@@ -45,34 +45,34 @@ describe('Service: User service', () => {
   ));
 
   let testUser = {
-    "attributes": {
-      "fullName": "name",
-      "imageURL": "",
-      "username": "myUser"
+    'attributes': {
+      'fullName': 'name',
+      'imageURL': '',
+      'username': 'myUser'
     },
-    "id": "userId",
-    "type": "userType"
+    'id': 'userId',
+    'type': 'userType'
   };
 
   let testUsers = [
     testUser,
     {
-      "attributes": {
-        "fullName": "secondUser",
-        "imageURL": "",
-        "username": "secondUser"
+      'attributes': {
+        'fullName': 'secondUser',
+        'imageURL': '',
+        'username': 'secondUser'
       },
-      "id": "secondUserId",
-      "type": "userType"
+      'id': 'secondUserId',
+      'type': 'userType'
     },
     {
-      "attributes": {
-        "fullName": "thirdUser",
-        "imageURL": "",
-        "username": "thirdUser+1@redhat.com"
+      'attributes': {
+        'fullName': 'thirdUser',
+        'imageURL': '',
+        'username': 'thirdUser+1@redhat.com'
       },
-      "id": "thirdUserId",
-      "type": "userType"
+      'id': 'thirdUserId',
+      'type': 'userType'
     }
   ];
 

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -102,7 +102,7 @@ export class UserService {
       .map(response => {
         return response.json().data as User;
       })
-      .catch(this.catchRequestError());
+      .catch(this.catchRequestError);
   }
 
   /**
@@ -130,7 +130,7 @@ export class UserService {
         .map(response => {
           return response.json().data as User[];
         })
-        .catch(this.catchRequestError());
+        .catch(this.catchRequestError);
     }
     return Observable.of([] as User[]);
   }
@@ -171,7 +171,7 @@ export class UserService {
       .map(response => {
         return response.json().data as User[];
       })
-      .catch(this.catchRequestError())
+      .catch(this.catchRequestError)
       // TODO remove this
       .do(val => this.allUserData = val);
   }
@@ -189,7 +189,7 @@ export class UserService {
       .map(response => {
         return response.json().data as User[];
       })
-      .catch(this.catchRequestError());
+      .catch(this.catchRequestError);
   }
 
   /**
@@ -201,7 +201,7 @@ export class UserService {
       .map((response: Response) => {
         return response;
       })
-      .catch(this.catchRequestError());
+      .catch(this.catchRequestError);
   }
 
   /**
@@ -212,12 +212,10 @@ export class UserService {
     this.userData = {} as User;
   }
 
-  private catchRequestError() {
-    return (response: Response) => {
-      if (isAuthenticationError(response)) {
-        this.broadcaster.broadcast('authenticationError', response);
-      }
-      return Observable.throw(response);
-    };
+  private catchRequestError = (response: Response) => {
+    if (isAuthenticationError(response)) {
+      this.broadcaster.broadcast('authenticationError', response);
+    }
+    return Observable.throw(response);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3736
Fixes https://github.com/openshiftio/openshift.io/issues/3746
Fixes https://github.com/fabric8-services/fabric8-auth/issues/535

- Adds header check to assert if `www-authenticate: login` is present in response.
- Adds a common method to check if login is required which is used by all the services.
- Check for auth error in authentication service while getting or refreshing the token.
- Check for auth error in user service while getting user data.
