### PR TITLE
 fix(auth): added tests for authentication.service and user.service handling catchRequestErrors

### DIFF
--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -200,8 +200,7 @@ export class UserService {
       .post(this.usersUrl + '/verificationcode', '', { headers: this.headers })
       .map((response: Response) => {
         return response;
-      })
-      .catch(this.catchRequestError);
+      });
   }
 
   /**

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -34,7 +34,10 @@ export class UserService {
    */
   public currentLoggedInUser: User = {} as User;
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> fix(auth): added tests for authentication.service and user.service handling catchRequestErrors
   /**
    * @deprecated since v0.4.4. Use {@link #loggedInUser} instead.
    */

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -34,10 +34,6 @@ export class UserService {
    */
   public currentLoggedInUser: User = {} as User;
 
-<<<<<<< HEAD
-
-=======
->>>>>>> fix(auth): added tests for authentication.service and user.service handling catchRequestErrors
   /**
    * @deprecated since v0.4.4. Use {@link #loggedInUser} instead.
    */

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -34,7 +34,6 @@ export class UserService {
    */
   public currentLoggedInUser: User = {} as User;
 
-  private broadcaster: Broadcaster;
 
   /**
    * @deprecated since v0.4.4. Use {@link #loggedInUser} instead.
@@ -54,7 +53,7 @@ export class UserService {
 
   constructor(private http: Http,
     private logger: Logger,
-    broadcaster: Broadcaster,
+    private broadcaster: Broadcaster,
     @Inject(AUTH_API_URL) apiUrl: string
   ) {
     this.userUrl = apiUrl + 'user';


### PR DESCRIPTION
- Additional tests for https://github.com/fabric8-ui/ngx-login-client/pull/113
- Removes `catchRequestErrors` from `sendEmailVerificationLink` as its not needed there.
- Using `private broadcaster: Broadcaster` inside the constructor.