### PR TITLE
[WIP] fix(auth): add auth interceptor to support HttpClient

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,13 +1,13 @@
-//import './rxjs-extensions';
-
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 // App components
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+import { AuthInterceptor } from './shared/auth.interceptor';
 
 // Main areas
 
@@ -21,7 +21,13 @@ import { AppRoutingModule } from './app-routing.module';
   declarations: [
     AppComponent
   ],
-  providers: [],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true
+    }
+  ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule { }

--- a/src/app/shared/auth.interceptor.spec.ts
+++ b/src/app/shared/auth.interceptor.spec.ts
@@ -1,0 +1,117 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Broadcaster } from 'ngx-base';
+import { AuthInterceptor } from './auth.interceptor';
+
+describe(`AuthHttpInterceptor`, () => {
+  const testUrl: string = 'http://localhost/test';
+  const testToken: string = 'test_token';
+
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+  let broadcaster: Broadcaster;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: AuthInterceptor,
+          multi: true
+        },
+        Broadcaster
+      ]
+    });
+    httpMock = TestBed.get(HttpTestingController);
+    httpClient = TestBed.get(HttpClient);
+    broadcaster = TestBed.get(Broadcaster);
+
+    spyOn(localStorage, 'getItem').and.callFake( (key: string): string => {
+      return key === 'auth_token' ? testToken : null;
+    });
+  });
+
+  it('should add an Authorization header', () => {
+    httpClient.get(testUrl).subscribe(() => {});
+
+    const req = httpMock.expectOne(testUrl);
+
+    expect(req.request.headers.has('Authorization'));
+    expect(req.request.headers.get('Authorization')).toBe(`Bearer ${testToken}`);
+  });
+
+  it('should broadcast authenticationError event on 401 with code jwt_security_error', () => {
+    let authenticationError = false;
+    let errored = false;
+
+    broadcaster.on('authenticationError').subscribe(() => {
+      authenticationError = true;
+    });
+
+    httpClient.get(testUrl).subscribe(() => { }, () => {
+      errored = true;
+    });
+
+    const req = httpMock.expectOne(testUrl);
+
+    // mock response
+    req.flush({ errors: [{ code: 'jwt_security_error' }] },
+      { status: 401, statusText: 'error' });
+
+    expect(authenticationError).toBe(true, 'authentication error');
+    expect(errored).toBe(true, 'request error');
+  });
+
+
+
+  it('should broadcast authenticationError event on 401 with auth header www-authenticate', () => {
+    let authenticationError = false;
+    let errored = false;
+
+    broadcaster.on('authenticationError').subscribe(() => {
+      authenticationError = true;
+    });
+
+    httpClient.get(testUrl).subscribe(() => { }, () => {
+      errored = true;
+    });
+
+    const req = httpMock.expectOne(testUrl);
+
+    // mock response
+    req.flush({ errors: [{ code: 'validation_error' }] }, {
+      status: 401, statusText: 'error', headers: {
+        'Www-Authenticate': 'LOGIN url=something.io login required'
+      }
+    });
+
+    expect(authenticationError).toBe(true, 'authentication error');
+    expect(errored).toBe(true, 'request error');
+  });
+
+  it('should not broadcast authenticationError event on 401', () => {
+    let authenticationError = false;
+    let errored = false;
+    broadcaster.on('authenticationError').subscribe(() => {
+      authenticationError = true;
+    });
+
+    httpClient.get(testUrl).subscribe(() => { }, () => {
+      errored = true;
+    });
+
+    const req = httpMock.expectOne(testUrl);
+
+    // mock response
+    req.flush('', { status: 401, statusText: 'error' });
+
+    expect(authenticationError).toBe(false, 'authentication error');
+    expect(errored).toBe(true, 'request error');
+  });
+
+});

--- a/src/app/shared/auth.interceptor.ts
+++ b/src/app/shared/auth.interceptor.ts
@@ -1,0 +1,58 @@
+import { Injectable, Inject, forwardRef } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpErrorResponse
+} from '@angular/common/http';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/operators/map';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/of';
+
+import { Broadcaster } from 'ngx-base';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+
+  constructor(@Inject(forwardRef(() => Broadcaster)) private broadcaster: Broadcaster) { }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    let token = localStorage.getItem('auth_token');
+    if (token !== null) {
+      request = request.clone({
+        setHeaders: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+    }
+    return next.handle(request).catch(this.catchRequestError);
+  }
+
+  private catchRequestError = (event: HttpEvent<any>) => {
+    if (event instanceof HttpErrorResponse) {
+      const res: HttpErrorResponse = event;
+      if (res.status === 403 || isAuthenticationError(res)) {
+        this.broadcaster.broadcast('authenticationError', res);
+      } else if (res.status === 500) {
+        this.broadcaster.broadcast('communicationError', res);
+      }
+    }
+    return Observable.throw(event);
+  }
+}
+
+function isAuthenticationError(res: HttpErrorResponse): boolean {
+  if (res.status === 401) {
+    const json: any = res.error;
+    const hasErrors: boolean = json && Array.isArray(json.errors);
+    const isJwtError: boolean = hasErrors &&
+      json.errors.filter((e: any) => e.code === 'jwt_security_error').length >= 1;
+    const authHeader = res.headers.get('www-authenticate');
+    const isLoginHeader = authHeader && authHeader.toLowerCase().includes('login');
+    return isJwtError || isLoginHeader;
+  }
+  return false;
+}


### PR DESCRIPTION
As part of upgrading to angular 6 we need to migrate to using the newer HttpClient api.

This PR moves the functionality of the `http.service` to an interceptor.