### PR TITLE
fix(dependency-injection): rename InjectionToken WIT_API_URL -> WIT_API_PROXY

### DIFF
--- a/src/app/auth/authentication.service.spec.ts
+++ b/src/app/auth/authentication.service.spec.ts
@@ -9,7 +9,7 @@ import { AuthInterceptor } from '../shared/auth.interceptor';
 import { SSO_API_URL } from '../shared/sso-api';
 import { AUTH_API_URL } from '../shared/auth-api';
 import { REALM } from '../shared/realm-token';
-import { WIT_API_URL } from '../shared/wit-api';
+import { WIT_API_PROXY } from '../shared/wit-api';
 
 describe('Service: Authentication service', () => {
 
@@ -34,7 +34,7 @@ describe('Service: Authentication service', () => {
         { provide: REALM, useValue: 'fabric8' },
         { provide: AUTH_API_URL, useValue: 'http://auth.example.com/' },
         { provide: SSO_API_URL, useValue: 'http://sso.example.com/auth' },
-        { provide: WIT_API_URL, useValue: 'http://wit.example.com'},
+        { provide: WIT_API_PROXY, useValue: 'http://wit.example.com'},
         Broadcaster
       ]
     });

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -3,6 +3,7 @@ export { LoginModule } from './login.module';
 export { REALM } from './shared/realm-token';
 export { AUTH_API_URL } from './shared/auth-api';
 export { SSO_API_URL } from './shared/sso-api';
+export { WIT_API_PROXY } from './shared/wit-api';
 export { AlmUserName } from './user/alm-user-name.pipe';
 export { AuthenticationService } from './auth/authentication.service';
 export { AuthInterceptor } from './shared/auth.interceptor';

--- a/src/app/shared/auth.interceptor.spec.ts
+++ b/src/app/shared/auth.interceptor.spec.ts
@@ -6,7 +6,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { Broadcaster } from 'ngx-base';
 import { AuthInterceptor } from './auth.interceptor';
-import { WIT_API_URL } from './wit-api';
+import { WIT_API_PROXY } from './wit-api';
 import { AUTH_API_URL } from './auth-api';
 import { SSO_API_URL } from './sso-api';
 
@@ -29,7 +29,7 @@ describe(`AuthHttpInterceptor`, () => {
           useClass: AuthInterceptor,
           multi: true
         },
-        { provide: WIT_API_URL, useValue: 'http://wit.example.com'},
+        { provide: WIT_API_PROXY, useValue: 'http://wit.example.com'},
         { provide: AUTH_API_URL, useValue: 'http://auth.example.com'},
         { provide: SSO_API_URL, useValue: 'http://sso.example.com'},
         Broadcaster

--- a/src/app/shared/auth.interceptor.ts
+++ b/src/app/shared/auth.interceptor.ts
@@ -13,7 +13,7 @@ import { tap } from 'rxjs/operators';
 
 import { Broadcaster } from 'ngx-base';
 
-import { WIT_API_URL } from './wit-api';
+import { WIT_API_PROXY } from './wit-api';
 import { AUTH_API_URL } from './auth-api';
 import { SSO_API_URL } from './sso-api';
 
@@ -22,7 +22,7 @@ export class AuthInterceptor implements HttpInterceptor {
 
   constructor(
     @Inject(forwardRef(() => Broadcaster)) private broadcaster: Broadcaster,
-    @Inject(WIT_API_URL) private witApiUrl: string,
+    @Inject(WIT_API_PROXY) private witApiUrl: string,
     @Inject(AUTH_API_URL) private authApiUrl: string,
     @Inject(SSO_API_URL) private ssoUrl: string
   ) {}

--- a/src/app/shared/wit-api.ts
+++ b/src/app/shared/wit-api.ts
@@ -1,3 +1,3 @@
 import { InjectionToken } from '@angular/core';
 
-export let WIT_API_URL = new InjectionToken<string>('fabric8.wit.api.url');
+export let WIT_API_PROXY = new InjectionToken<string>('fabric8.wit.api.proxy');

--- a/src/app/user/user.service.spec.ts
+++ b/src/app/user/user.service.spec.ts
@@ -8,7 +8,7 @@ import { AUTH_API_URL } from '../shared/auth-api';
 import { UserService } from './user.service';
 import { AuthInterceptor } from '../shared/auth.interceptor';
 import { SSO_API_URL } from '../shared/sso-api';
-import { WIT_API_URL } from '../shared/wit-api';
+import { WIT_API_PROXY } from '../shared/wit-api';
 
 
 describe('Service: User service', () => {
@@ -29,7 +29,7 @@ describe('Service: User service', () => {
         },
         { provide: AUTH_API_URL, useValue: 'http://auth.example.com/' },
         { provide: SSO_API_URL, useValue: 'http://sso.example.com/auth' },
-        { provide: WIT_API_URL, useValue: 'http://wit.example.com'},
+        { provide: WIT_API_PROXY, useValue: 'http://wit.example.com'},
         Broadcaster,
         Logger
       ]


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-auth/issues/679

- Renames  InjectionToken `WIT_API_URL` -> `WIT_API_PROXY` to fix dependency injection issue in `fabric8-ui`